### PR TITLE
remove misleading log entry

### DIFF
--- a/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/jacoco/AbstractAnalyzer.java
+++ b/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/jacoco/AbstractAnalyzer.java
@@ -130,7 +130,6 @@ public abstract class AbstractAnalyzer {
       JaCoCoExtensions.logger().warn("No binary directories defined.");
     }
     for (File binaryDir : binaryDirs) {
-      JaCoCoExtensions.logger().info("\tChecking binary directory: {}", binaryDir.toString());
       if (binaryDir.exists()) {
         return true;
       }


### PR DESCRIPTION
The log message is misleading here as one could think that only one of the binary directories is used.

```
INFO: Sensor Groovy JaCoCo [groovy]
INFO:   Checking binary directory: /home/me/project/target/classes
INFO: Analysing /home/me/project/target/jacoco.exec
```